### PR TITLE
Updated grunt-contrib-copy to version 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-concat": "0.1.6",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-concat": "0.5.1",
-    "grunt-contrib-copy": "0.7.0",
+    "grunt-contrib-copy": "0.8.1",
     "grunt-contrib-jshint": "0.11.3",
     "grunt-contrib-uglify": "0.8.1",
     "grunt-html2js": "0.3.4",


### PR DESCRIPTION
:rocket:

grunt-contrib-copy just published version 0.8.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 22 commits (ahead by 22, behind by 0).
- [84e1993](https://github.com/gruntjs/grunt-contrib-copy/commit/84e19938d3b17df190228bf9c2c35cd3b6a16ce4): 0.8.1
- [689c734](https://github.com/gruntjs/grunt-contrib-copy/commit/689c734ad50d322a5e105a52cb45c9326f6b660c): changelog
- [b8a8307](https://github.com/gruntjs/grunt-contrib-copy/commit/b8a83070166c3dbcd2399bc78e1675f78ce95694): Merge pull request #233 from pgilad/patch-1
- [13d2f09](https://github.com/gruntjs/grunt-contrib-copy/commit/13d2f09dfc76b813770753fad8f9b91931c5e193): Update license attribute
- [8ba6d9a](https://github.com/gruntjs/grunt-contrib-copy/commit/8ba6d9a7e15afe1122526d20be61f677a8e42ad1): Merge pull request #224 from suguiura/patch-1
- [376400c](https://github.com/gruntjs/grunt-contrib-copy/commit/376400c7ab44611c529cddb9dc98c8fd36bd0bde): Bump README.md
- [52f07be](https://github.com/gruntjs/grunt-contrib-copy/commit/52f07bef5dbb94c57bd9bdb58e6bc5f01da9c204): bump `chalk`
- [e7329ed](https://github.com/gruntjs/grunt-contrib-copy/commit/e7329ed62d730d44142617f1af3e43b7e533f24c): 0.8.0
- [a76e9a4](https://github.com/gruntjs/grunt-contrib-copy/commit/a76e9a43a920d4e10074188e53b17f71bf7473ed): changelog
- [a15feec](https://github.com/gruntjs/grunt-contrib-copy/commit/a15feecc7763269e995235dcb4647b223d67f516): don't redefine `src`
- [977a590](https://github.com/gruntjs/grunt-contrib-copy/commit/977a590dd6d5b170cf35efb7930fad0641cc771c): bump deps
- [647841e](https://github.com/gruntjs/grunt-contrib-copy/commit/647841e4f2d52dbe2eb5d4f1fa5d7c308507e459): Merge pull request #180 from BorePlusPlus/detect-dir
- [16c2dfa](https://github.com/gruntjs/grunt-contrib-copy/commit/16c2dfa1ea72191a4a5916c901e4d9e299ad9476): minor tweaks
- [be9e521](https://github.com/gruntjs/grunt-contrib-copy/commit/be9e52199f1ea823e8b19f9792c9ab5d041af5b4): Update copyright to 2015
- [6b7d1f4](https://github.com/gruntjs/grunt-contrib-copy/commit/6b7d1f475151c81c3c1e0e0bbe0f53fadea5937c): Merge pull request #204 from mgeisler/improve-file-comparison

There are 22 commits in total. See the [full diff](https://github.com/gruntjs/grunt-contrib-copy/compare/d549a9ee6351e7dda0a99fe634993bdcac4b480c...84e19938d3b17df190228bf9c2c35cd3b6a16ce4).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
