### PR TITLE
feat: add requireUserWithRoles helper on $provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ the `resolve` option of the `when` method of the `$routeProvider`, or
 as values for analogous options passed to the Angular UI router. Check
 [Angular's
 documentation](https://docs.angularjs.org/api/ngRoute/provider/$routeProvider)
-for more information. Note that `requireAdminUser` and
-`requireAuthenticatedUser` are designed to work this way, and need to
+for more information. Note that `requireAdminUser`,
+`requireAuthenticatedUser` and `requireUserWithRoles` are designed to work this way, and need to
 have their arguments injected by `$routeProvider`, so use them for
 example like this:
 
@@ -163,6 +163,22 @@ _Note_: These functions are created dynamically during the configuration of the 
       }
     });
   }
+```
+
+#### `requireUserWithRoles`
+
+_Promise/A+_ Check if the user is has a role in the given set.
+
+Similar to [require<role-name>User](#requirerole-nameuser) but supports checking against multiple roles, for example:
+
+```js
+// Within a $stateProvider.state declaration
+resolve: {
+  authorization: ehaCouchDbAuthServiceProvider.requireUserWithRoles([
+    'data_provider',
+    'analyst'
+  ])
+}
 ```
 
 #### `requireAuthenticatedUser`

--- a/src/auth.service.js
+++ b/src/auth.service.js
@@ -297,6 +297,12 @@
                 });
     };
 
+    this.requireUserWithRoles = function(roles) {
+      return function(ehaCouchDbAuthService, $q) {
+        return requireUserWithRoles(ehaCouchDbAuthService, $q, roles);
+      };
+    };
+
     this.$get = function(Restangular, $log, $q, $localForage, $rootScope) {
 
       var restangular = Restangular.withConfig(


### PR DESCRIPTION
Saves having to role it out each time using
`ehaCouchDbAuthService#getCurrentUser` and `user#hasRole`, for example [in
van][1] and [ddd][2].

[1]: https://github.com/eHealthAfrica/van/blob/5f90e3dad0571bcdaa58cb66b4227224a48eeb28/app/routes.js#L113-L120
[2]: https://github.com/eHealthAfrica/direct-delivery-dashboard/blob/98bfed4de8828d8461bd1d49e737b7b158c2a808/src/app/components/auth/auth.service.js#L12-L25