### PR TITLE
feat(api): provide fun. for proxy auth session

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Calling `resetPassword()` with a valid `token` and a new `password` will initiat
 
 _Promise/A+_ Makes a GET request to the `_session/` endpoint of the CouchDB url provided during configuration. _Returns a promise._
 
+
+#### `getUserFromSession()`
+
+Intended to be used with a couchdb proxy auth setup.
+
+_Promise/A+_ Makes a GET request to the `_session/` endpoint of the CouchDB url provided during configuration. _Returns a promise._
+If session is returned, the user will be persisted.
+
 #### `getCurrentUser()`
 
 _Promise/A+_ Checks the local environment for a user, failing that checks local storage and finally attempts to GET the `_session/` endpoint of the CouchDB url.

--- a/src/auth.service.js
+++ b/src/auth.service.js
@@ -39,6 +39,29 @@
                       });
     }
 
+    function getUserFromSession(user) {
+      return getSession()
+      .then(setCurrentUser)
+      .then(function(user) {
+        if (!user || !user.ok) {
+          $log.debug('couchdb:login:failure:unknown');
+          return $q.reject(new Error());
+        }
+        eventBus.$broadcast('authenticationStateChange');
+        $log.debug('couchdb:login:success', user);
+        return decorateUser(user);
+      })
+      .catch(function(err) {
+        if (err.status === 401) {
+          $log.debug('couchdb:login:failure:invalid-credentials', err);
+          return $q.reject(new Error('Invalid Credentials'));
+        } else {
+          $log.debug('couchdb:login:failure:unknown', err);
+          return $q.reject(new Error(err));
+        }
+      });
+    }
+
     function signIn(user) {
       return $q.when(Restangular
         .all(options.sessionEndpoint)
@@ -197,6 +220,7 @@
         remove: removeAccount
       },
       getSession: getSession,
+      getUserFromSession: getUserFromSession,
       getCurrentUser: getCurrentUser,
       on: eventBus.$on.bind(eventBus),
       trigger: eventBus.$broadcast.bind(eventBus),


### PR DESCRIPTION
proxy auth enables requesting session in
a different manner as previous based on login/logout.

we add a new API endpoint to request session and persit
it to a local storage, simmilar to what a login functionality
will do

part of [POLIOEOC-233]
